### PR TITLE
getScope become static in SerializableMock

### DIFF
--- a/src/Majora/Framework/Serializer/Model/SerializableTrait.php
+++ b/src/Majora/Framework/Serializer/Model/SerializableTrait.php
@@ -17,7 +17,7 @@ trait SerializableTrait
     /**
      * @see SerializableInterface::getScopes()
      */
-    abstract public function getScopes();
+    abstract public static function getScopes();
 
     /**
      * @see SerializableInterface::serialize()

--- a/src/Majora/Framework/Serializer/Tests/Model/SerializableMock1.php
+++ b/src/Majora/Framework/Serializer/Tests/Model/SerializableMock1.php
@@ -119,7 +119,7 @@ class SerializableMock1
     /**
      * @see ScopableInterface::getScopes()
      */
-    public function getScopes()
+    public static function getScopes()
     {
         return array(
             'default' => array('id', 'label'),

--- a/src/Majora/Framework/Serializer/Tests/Model/SerializableMock2.php
+++ b/src/Majora/Framework/Serializer/Tests/Model/SerializableMock2.php
@@ -53,7 +53,7 @@ class SerializableMock2
     /**
      * @see ScopableInterface::getScopes()
      */
-    public function getScopes()
+    public static function getScopes()
     {
         return array(
             'default' => array('id', 'label', 'table'),


### PR DESCRIPTION
To respect ScopableInterface::getScopes() and make the tests green