### PR TITLE
http bundle implementation

### DIFF
--- a/src/Majora/Bundle/FrameworkExtraBundle/DependencyInjection/Configuration.php
+++ b/src/Majora/Bundle/FrameworkExtraBundle/DependencyInjection/Configuration.php
@@ -52,6 +52,11 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('json_form_extension')
                     ->canBeEnabled()
                 ->end()
+                ->arrayNode('http_extension')
+                    ->canBeEnabled()
+                    ->children()
+                    ->scalarNode('path')->end()
+                ->end()
             ->end()
         ;
 

--- a/src/Majora/Bundle/FrameworkExtraBundle/DependencyInjection/MajoraFrameworkExtraExtension.php
+++ b/src/Majora/Bundle/FrameworkExtraBundle/DependencyInjection/MajoraFrameworkExtraExtension.php
@@ -64,5 +64,17 @@ class MajoraFrameworkExtraExtension extends Extension
         if (!empty($config['json_form_extension']['enabled'])) {
             $loader->load('json_form_extension.xml');
         }
+
+
+        // http_extension
+        if(!empty($config['http_extension']['enabled']))
+        {
+            $loader->load('http_extension.xml');
+            new HttpClientFactory($container, $config['http_extension']);
+
+            if ($container->getParameter('kernel.debug')) {
+                $loader->load('http_datacollector.xml');
+            }
+        }
     }
 }

--- a/src/Majora/Bundle/FrameworkExtraBundle/Resources/config/http_datacollector.xml
+++ b/src/Majora/Bundle/FrameworkExtraBundle/Resources/config/http_datacollector.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="majora.http_collector" class="Majora\Framework\Http\DataCollector\MajoraHttpDataCollector">
+            <tag name="data_collector" template="MajoraFrameworkExtraBundle:Collector:majorahttp" id="majorahttp" priority="254"/>
+            <tag name="kernel.event_listener" event="majora_http.event" method="onRequest"/>
+        </service>
+    </services>
+</container>

--- a/src/Majora/Bundle/FrameworkExtraBundle/Resources/config/http_extension.xml
+++ b/src/Majora/Bundle/FrameworkExtraBundle/Resources/config/http_extension.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"  ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="guzzle_wrapper" class="Majora\Framework\Http\Services\GuzzleWrapper">
+            <argument type="service" id="guzzle.curl_handler"/>
+        </service>
+        <service id="guzzle.curl_handler" class="GuzzleHttp\Handler\CurlHandler">
+            <factory class="GuzzleHttp\HandlerStack" method="create"/>
+        </service>
+        <service id="majora.http_eventdispatcher" class="Majora\Framework\Http\Middleware\MajoraEventDispatcher">
+            <argument type="service" id="debug.stopwatch"/>
+            <argument type="service" id="event_dispatcher"/>
+            <argument/>
+        </service>
+    </services>
+</container>
+

--- a/src/Majora/Bundle/FrameworkExtraBundle/Resources/views/Collector/majorahttp.html.twig
+++ b/src/Majora/Bundle/FrameworkExtraBundle/Resources/views/Collector/majorahttp.html.twig
@@ -1,0 +1,94 @@
+{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+
+{% block toolbar %}
+    {% set text %}
+        {# this is the content displayed when hovering the mouse over
+              the toolbar panel #}
+        {% set icon %}
+            <span class="sf-toolbar-value">MajoraHttp</span>
+        {% endset %}
+        <div class="sf-toolbar-info-piece">
+            <b>MajoraHttp</b>
+        </div>
+
+    {% endset %}
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true }) }}
+{% endblock %}
+
+{% block menu %}
+    <span class="label">
+        <span class="icon"></span>
+        <strong>Majora HTTP</strong>
+        <span class="count">{{ collector.commands|length }}</span>
+    </span>
+{% endblock %}
+
+{% block panel %}
+
+
+    <h2><b>Majora HTTP</b></h2>
+    {% for command in collector.commands %}
+
+        <span style="font-size: 16px; font-weight: bold;">Request URI </span>: {{ command.uri }}<br>
+        <br>
+        <b>REQUEST</b>
+        <table>
+            <thead>
+            <th>Method</th>
+            <th>Content-Type</th>
+            <th>Host</th>
+            {% if command.headers.apiKey is defined %}
+                <th>ApiKey</th>
+            {% endif %}
+            </thead>
+            <td>
+                {{ command.method }}
+            </td>
+            <td>
+                {% if command.headers['Content-Type'][0]  is defined %}
+                    {{ command.headers['Content-Type'][0] }}
+                {% else %}
+                    null
+                {% endif %}
+            </td>
+            <td>
+                {{ command.headers['Host'][0] }}
+            </td>
+            {% if command.headers.apiKey is defined %}
+                <td>
+                    {{ command.headers['api_key'][0] }}
+                </td>
+            {% endif %}
+        </table>
+
+
+        <b>RESPONSE</b>
+        <table>
+            <thead>
+            <th>Status Code</th>
+            <th>Message</th>
+            <th>Execution Time</th>
+            </thead>
+
+            <td>
+                {{ command.statusCode }}
+            </td>
+            <td>
+                {{ command.reasonPhrase}}</td>
+            </td>
+            <td>
+                {{ command.executionTime }} ms
+            </td>
+        </table>
+        <table>
+            <thead>
+            <th>Body</th>
+            </thead>
+            <td>
+                {{ command.responseBody|slice(0,100)|json_encode }}
+            </td>
+        </table>
+        <br><br><br>
+    {% endfor %}
+
+{% endblock %}

--- a/src/Majora/Framework/Http/DataCollector/MajoraHttpDataCollector.php
+++ b/src/Majora/Framework/Http/DataCollector/MajoraHttpDataCollector.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace  Majora\Framework\Http\DataCollector;
+
+use Majora\Framework\Http\Event\HttpRequestEvent;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+
+
+/**
+ * Class MajoraHttpDataCollector
+ * @package Majora\HttpBundle\DataCollector
+ */
+class MajoraHttpDataCollector extends DataCollector
+{
+
+    /**
+     * MajoraHttpDataCollector constructor.
+     */
+    public function __construct()
+    {
+        $this->data['majoraHttp'] = [
+            'commands' => new \SplQueue(),
+        ];
+    }
+
+    /**
+     * @param Request $request
+     * @param Response $response
+     * @param \Exception|null $exception
+     */
+    function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+
+    }
+
+    /**
+     * @return string
+     */
+    function getName()
+    {
+        return "majorahttp";
+    }
+
+    /**
+     * @param MajoraHttpEvent $event
+     */
+    public function onRequest(HttpRequestEvent $event)
+    {
+        $request = $event->getRequest();
+        $response = $event->getResponse();
+        $body = (array) json_decode($response->getBody());
+
+        $data = array(
+            'responseBody' => $body,
+            'uri' => $request->getUri(),
+            'method' => $request->getMethod(),
+            'headers' => $request->getHeaders(),
+            'statusCode' => $response->getStatusCode(),
+            'reasonPhrase' => $response->getReasonPhrase(),
+            'executionTime' => $event->getExecutionTime(),
+        );
+
+        $this->data['majoraHttp']['commands']->enqueue($data);
+    }
+
+    public function getCommands()
+    {
+        return $this->data['majoraHttp']['commands'];
+    }
+
+}

--- a/src/Majora/Framework/Http/Event/HttpRequestEvent.php
+++ b/src/Majora/Framework/Http/Event/HttpRequestEvent.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Majora\Framework\Http\Event;
+
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\EventDispatcher\Event;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class HttpRequestEvent extends Event
+{
+    const EVENT_NAME = 'majora_http.event';
+
+    /**
+     * Command execution time
+     *
+     * @var float
+     */
+    protected $executionTime;
+    /**
+     * @var Request
+     */
+    protected $request;
+    /**
+     * @var Response
+     */
+    protected $response;
+
+    /**
+     * @var mixed
+     */
+    protected $reason;
+
+    /**
+     * @var string
+     */
+    protected $clientId;
+
+    public function __construct(RequestInterface $request, $clientId)
+    {
+        $this->request= $request;
+        $this->clientId = $clientId;
+    }
+
+    /**
+     * Return request
+     *
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+    /**
+     * Set Response
+     *
+     * @param Response $response
+     *
+     * @return $this
+     */
+    public function setResponse(ResponseInterface $response)
+    {
+        $this->response = $response;
+        $this->reason = $this->response->getReasonPhrase();
+        return $this;
+    }
+    /**
+     * Return response
+     *
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+
+    /**
+     * @return float
+     */
+    public function getExecutionTime()
+    {
+        return $this->executionTime;
+    }
+
+
+    public function setExecutionTime($time)
+    {
+        $this->executionTime = $time;
+    }
+}

--- a/src/Majora/Framework/Http/HttpClientFactory.php
+++ b/src/Majora/Framework/Http/HttpClientFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Majora\Framework\Http;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Yaml\Parser;
+
+
+
+class HttpClientFactory
+{
+    public function __construct($container, $config)
+    {
+        $this->config = $config;
+        $this->container = $container;
+        $this->init();
+    }
+
+
+    public function init()
+    {
+        $parser = new Parser();
+        if(!empty($this->config['path'])) {
+            $clients = $parser->parse(file_get_contents($this->container->getParameter('kernel.root_dir').$this->config['path']));
+        }
+        else {
+            $clients = $parser->parse(file_get_contents($this->container->getParameter('kernel.root_dir').'/majora_client.yml'));
+        }
+
+        foreach ($clients as $clientId => $clientConfig)
+        {
+            $this->createClient($clientConfig, $clientId);
+        }
+    }
+
+    public function createClient($clientConfig, $clientId){
+
+        $this->container->setDefinition(sprintf('majora_http.handler.%s', $clientId), $this->container->getDefinition('guzzle.curl_handler'));
+        $handlerStackReference = new Reference(sprintf('majora_http.handler.%s', $clientId));
+
+        $this->container->getDefinition(sprintf('majora_http.handler.%s', $clientId));
+
+        //Middleware
+        $eventDispatcher = $this->container->getDefinition('majora.http_eventdispatcher');
+        $eventDispatcher->replaceArgument(2, $clientId);
+        $eventDispatcher->addMethodCall('push', [$handlerStackReference]);
+
+        $clientConfig['handler'] = $handlerStackReference;
+        $clientConfig['middleware'] = $eventDispatcher;
+        $guzzleClient= $this->container->getDefinition('guzzle_wrapper');
+        $guzzleClient->replaceArgument(0, $clientConfig);
+        $this->container->setDefinition(sprintf('guzzle_http.%s', $clientId) , $guzzleClient);
+    }
+}
+
+
+

--- a/src/Majora/Framework/Http/Middleware/MajoraEventDispatcher.php
+++ b/src/Majora/Framework/Http/Middleware/MajoraEventDispatcher.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Majora\Framework\Http\Middleware;
+
+
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\PrepareBodyMiddleware;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Majora\Framework\Http\Event\HttpRequestEvent;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class MajoraEventDispatcher
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+    /**
+     * @var array
+     */
+    protected $event;
+    /**
+     * @var string
+     */
+    protected $clientId;
+
+    /**
+     * MajoraEventDispatcher constructor.
+     * @param $stopWatch
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param $clientId
+     */
+    public function __construct(Stopwatch $stopWatch, EventDispatcherInterface $eventDispatcher, $clientId)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->clientId = $clientId;
+        $this->stopWatch = $stopWatch;
+    }
+
+    /**
+     * @param HandlerStack $stack
+     * @return HandlerStack
+     */
+    public function push(HandlerStack $stack)
+    {
+        $stack->push(Middleware::mapRequest(function (RequestInterface $request) {
+            $this->initEvent($request);
+            return $request;
+        }));
+
+
+        $stack->push(function (callable $handler) {
+            return function (
+                RequestInterface $request,
+                array $options
+            ) use ($handler) {
+
+                $promise = $handler($request, $options);
+
+                return $promise->then(
+                    function (ResponseInterface $response) use ($request) {
+
+                        $this->dispatchEvent($response);
+                        return $response;
+                    },
+                    function (\Exception $reason) use ($request) {
+                        // impossible to pass \exception to dispatch event
+                        dump($reason);
+                        $this->dispatchEvent($reason);
+                        throw $reason;
+                    }
+                );
+            };
+        });
+        return $stack;
+    }
+
+    /**
+     * @param RequestInterface $request
+     */
+    protected function initEvent(RequestInterface $request)
+    {
+        $this->stopWatch->start('majoraEvent.'.$this->clientId);
+        $event = new HttpRequestEvent($request, $this->clientId);
+        $this->event = $event;
+    }
+
+    /**
+     * @param ResponseInterface $response
+     */
+    protected function dispatchEvent(ResponseInterface $response)
+    {
+        $this->event->setResponse($response);
+        $this->stopWatch->stop('majoraEvent.'.$this->clientId);
+        $this->event->setExecutionTime($this->stopWatch->getEvent('majoraEvent.'.$this->clientId)->getDuration());
+        $this->eventDispatcher->dispatch(HttpRequestEvent::EVENT_NAME, $this->event);
+    }
+}

--- a/src/Majora/Framework/Http/Services/GuzzleWrapper.php
+++ b/src/Majora/Framework/Http/Services/GuzzleWrapper.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Majora\Framework\Http\Services;
+
+use GuzzleHttp\Client;
+
+
+class GuzzleWrapper extends Client
+{
+    protected $clientConfig;
+
+    /**
+     * GuzzleWrapper constructor.
+     * @param $client
+     */
+    public function __construct(array $config)
+    {
+        parent::__construct($config);
+    }
+}


### PR DESCRIPTION
Pour ne pas polluer le dependency injection de majora, j'ai fait une classe, sans doute mal nommée (HttpClientFactory) qui est instanciée si on active l'extension http dans la config. Cette classe va aller chercher un .yml au path qu'on peux configurer, ou pas. Le .yml contient la config des clients guzzle et va etre parser et va créer les services pour chaque clients que l'on met dans le .yml