### PR TITLE
Fix majora denormalizer to handle case of $data == denormalized $object without constructor

### DIFF
--- a/src/Majora/Framework/Normalizer/MajoraNormalizer.php
+++ b/src/Majora/Framework/Normalizer/MajoraNormalizer.php
@@ -365,6 +365,12 @@ class MajoraNormalizer
             return $object;
         }
 
+        // In case $data is $object already denormalize,
+        // but it reached this point because $object doesn't have __construct() method
+        if (is_a($data, get_class($object))) {
+            return $data;
+        }
+
         $write = \Closure::bind(
             $this->createWrittingDelegate(),
             $object,


### PR DESCRIPTION
## Why
I need this (for SiR) to be able to denormalize an entity on creation given an associated entity.

example:
```
{
    "associated_entity":  1,
    "scalar": "blabla"
}
```